### PR TITLE
Enhancement: Adds new GitHub Issue forms template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_issue_form.yaml
+++ b/.github/ISSUE_TEMPLATE/new_issue_form.yaml
@@ -1,0 +1,30 @@
+name: Create a new issue
+description: Create a new issue using the latest issue forms
+body:
+  - type: markdown
+    attribute:
+      value: "### Thank you for raising the issue, please go through the instructions carefully"
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      options:
+        - Choose issue type
+        - Contribution
+        - Bug Report
+        - Other
+  - type: textarea
+    attributes:
+      label: Issue Description
+      placeholder: Please elaborate your issue as much as possible
+  - type: textarea
+    attributes:
+      lable: Screenshots and Logs
+      placeholder: Please attach and screenshots and logs in this section
+  - type: checkboxes
+    attributes:
+      label: Checked for duplicate issues?
+      options:
+        - labels: I have checked existing [open issues](https://github.com/ashwinexe/awesome-anvil/issues) for duplicates.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new_issue_form.yaml
+++ b/.github/ISSUE_TEMPLATE/new_issue_form.yaml
@@ -18,13 +18,13 @@ body:
       placeholder: Please elaborate your issue as much as possible
   - type: textarea
     attributes:
-      lable: Screenshots and Logs
+      label: Screenshots and Logs
       placeholder: Please attach and screenshots and logs in this section
   - type: checkboxes
     attributes:
       label: Checked for duplicate issues?
       options:
-        - labels: I have checked existing [open issues](https://github.com/ashwinexe/awesome-anvil/issues) for duplicates.
+        - label: I have checked existing [open issues](https://github.com/ashwinexe/awesome-anvil/issues) for duplicates.
           required: true
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new_issue_form.yaml
+++ b/.github/ISSUE_TEMPLATE/new_issue_form.yaml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Checked for duplicate issues?
       options:
-        - label: I have checked existing [open issues](https://github.com/ashwinexe/awesome-anvil/issues) for duplicates.
+        - label: I have checked existing [open issues](https://github.com/anvil-works/awesome-anvil/issues) for duplicates.
           required: true
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new_issue_form.yaml
+++ b/.github/ISSUE_TEMPLATE/new_issue_form.yaml
@@ -2,7 +2,7 @@ name: Create a new issue
 description: Create a new issue using the latest issue forms
 body:
   - type: markdown
-    attribute:
+    attributes:
       value: "### Thank you for raising the issue, please go through the instructions carefully"
   - type: dropdown
     attributes:


### PR DESCRIPTION
This PR adds the new [GitHub issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#about-yaml-syntax-for-issue-forms) to this repository, making it
- Visually appealing for new and existing contributors.
- Intentional in organizing issue data
- Set issues up for parsing if needed via [GitHub Actions](https://github.com/features/actions)

This is a contribution in good faith, Feel free to suggest changes or reject this feature. 